### PR TITLE
[BUGFIX] useDateAndTime: show HH:mm, add 24/12hr and hijri/miladi opt…

### DIFF
--- a/src/features/solah/hooks/useDateAndTime.ts
+++ b/src/features/solah/hooks/useDateAndTime.ts
@@ -1,47 +1,171 @@
-import { useState, useEffect } from "react";
+// features/solah/hooks/useDateAndTime.ts
+import { useEffect, useMemo, useState } from "react";
 
 export interface DateAndTime {
   date: string;
   time: string;
 }
 
-const formatDate = (d: Date): string =>
-  d.toLocaleDateString("en-US", {
-    weekday: "long",
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-  });
+type TimeFormat = "24hr" | "12hr";
+type Calendar = "hijri" | "miladi";
 
-const formatTime = (d: Date): string =>
-  d.toLocaleTimeString("en-US", {
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-    hour12: true,
-  });
+interface UseDateAndTimeOptions {
+  timeFormat?: TimeFormat; // default '24hr'
+  calendar?: Calendar; // default 'hijri'
+  locale?: string; // default 'en-US'
+}
 
-export const useDateAndTime = (): DateAndTime => {
-  const now = new Date();
-  const [date, setDate] = useState(() => formatDate(now));
-  const [time, setTime] = useState(() => formatTime(now));
+/**
+ * useDateAndTime
+ *
+ * - Default: timeFormat = '24hr', calendar = 'hijri', locale = 'en-US'
+ * - Time shows hours and minutes only (no seconds).
+ * - Supports 12hr/24hr formats.
+ * - Supports Hijri and Miladi (Gregorian) date formatting; Hijri default.
+ * - Efficient: updates aligned to the next minute, then every minute.
+ */
+export const useDateAndTime = (options: UseDateAndTimeOptions = {}): DateAndTime => {
+  const { timeFormat = "24hr", calendar = "hijri", locale = "en-US" } = options;
 
+  const [current, setCurrent] = useState<Date>(() => new Date());
+
+  // ---- Format Time ----
+  const formatTime = (d: Date): string => {
+    const minutes = d.getMinutes().toString().padStart(2, "0");
+
+    if (timeFormat === "24hr") {
+      const hours = d.getHours().toString().padStart(2, "0");
+      return `${hours}:${minutes}`;
+    }
+
+    const hours24 = d.getHours();
+    const period = hours24 >= 12 ? "PM" : "AM";
+    let hours12 = hours24 % 12;
+    if (hours12 === 0) hours12 = 12;
+    return `${hours12}:${minutes} ${period}`;
+  };
+
+  // ---- Format Date ----
+  const tryIntlDate = (d: Date, useHijri: boolean) => {
+    try {
+      const localeOption = useHijri ? `${locale}-u-ca-islamic` : locale;
+      const formatter = new Intl.DateTimeFormat(localeOption, {
+        day: "numeric",
+        month: "long",
+        year: "numeric",
+      });
+      return formatter.format(d);
+    } catch {
+      return null;
+    }
+  };
+
+  // Approximate arithmetic Hijri fallback (for runtimes without Intl islamic calendar)
+  const hijriFallback = (d: Date): string => {
+    const gY = d.getFullYear();
+    const gM = d.getMonth() + 1;
+    const gD = d.getDate();
+
+    const a = Math.floor((14 - gM) / 12);
+    const y = gY + 4800 - a;
+    const m = gM + 12 * a - 3;
+    const jd =
+      gD +
+      Math.floor((153 * m + 2) / 5) +
+      365 * y +
+      Math.floor(y / 4) -
+      Math.floor(y / 100) +
+      Math.floor(y / 400) -
+      32045;
+
+    const islamicEpoch = 1948439;
+    const days = jd - islamicEpoch;
+    const islamicYear = Math.floor((30 * days + 10646) / 10631);
+
+    const islamicToJd = (iy: number, im: number, id: number) =>
+      id +
+      Math.ceil(29.5 * (im - 1)) +
+      (iy - 1) * 354 +
+      Math.floor((3 + 11 * iy) / 30) +
+      islamicEpoch -
+      1;
+
+    let month = 1;
+    for (let mtest = 1; mtest <= 12; mtest++) {
+      const start = islamicToJd(islamicYear, mtest, 1);
+      const nextStart = islamicToJd(islamicYear, mtest + 1, 1);
+      if (jd >= start && jd < nextStart) {
+        month = mtest;
+        break;
+      }
+    }
+
+    const firstDayOfMonth = islamicToJd(islamicYear, month, 1);
+    const dayOfMonth = jd - firstDayOfMonth + 1;
+
+    const hijriMonths = [
+      "Muharram",
+      "Safar",
+      "Rabi' al-awwal",
+      "Rabi' al-thani",
+      "Jumada al-awwal",
+      "Jumada al-thani",
+      "Rajab",
+      "Sha'ban",
+      "Ramadan",
+      "Shawwal",
+      "Dhu al-Qadah",
+      "Dhu al-Hijjah",
+    ];
+
+    const monthName = hijriMonths[Math.max(0, Math.min(11, month - 1))] ?? `${month}`;
+    return `${dayOfMonth} ${monthName} ${islamicYear}`;
+  };
+
+  const formatDate = (d: Date): string => {
+    const useHijri = calendar === "hijri";
+    const intlResult = tryIntlDate(d, useHijri);
+    if (intlResult) return intlResult;
+    if (useHijri) return hijriFallback(d);
+
+    // Gregorian fallback
+    try {
+      return new Intl.DateTimeFormat(locale, {
+        day: "numeric",
+        month: "long",
+        year: "numeric",
+      }).format(d);
+    } catch {
+      return `${d.getDate()}/${d.getMonth() + 1}/${d.getFullYear()}`;
+    }
+  };
+
+  // ---- Update aligned to minute boundary ----
   useEffect(() => {
-    // update time every second
-    const timeInterval = setInterval(() => {
-      setTime(formatTime(new Date()));
-    }, 1000);
+    let intervalId: ReturnType<typeof setInterval> | null = null;
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
 
-    // update date every minute (midnight rollover)
-    const dateInterval = setInterval(() => {
-      setDate(formatDate(new Date()));
-    }, 60000);
+    const tick = () => setCurrent(new Date());
+
+    // initial sync immediately
+    setCurrent(new Date());
+
+    const nowDt = new Date();
+    const msUntilNextMinute = (60 - nowDt.getSeconds()) * 1000 - nowDt.getMilliseconds();
+
+    timeoutId = setTimeout(() => {
+      tick();
+      intervalId = setInterval(tick, 60 * 1000);
+    }, msUntilNextMinute);
 
     return () => {
-      clearInterval(timeInterval);
-      clearInterval(dateInterval);
+      if (timeoutId) clearTimeout(timeoutId);
+      if (intervalId) clearInterval(intervalId);
     };
-  }, []);
+  }, [timeFormat, calendar, locale]);
+
+  const time = useMemo(() => formatTime(current), [current, timeFormat]);
+  const date = useMemo(() => formatDate(current), [current, calendar, locale]);
 
   return { date, time };
 };


### PR DESCRIPTION
…ions (defaults: 24hr ✅ Update Summary

Fixed the time display to show only hours and minutes (removed seconds).

Added support for both 12-hour and 24-hour time formats.

Default is 24-hour, as per the design.

Added support for Hijri and Miladi (Gregorian) date systems.

Default is Hijri, matching the design.

Updated the useDateAndTime hook to accept optional configuration parameters:

const { date, time } = useDateAndTime({
  timeFormat: '24hr' | '12hr',
  calendar: 'hijri' | 'miladi'
});


Verified the output locally — matches the expected behavior described in the issue.+ hijri)