### PR TITLE
feat: add current solah time list with active highlight

### DIFF
--- a/src/app/guide/[solah_name].tsx
+++ b/src/app/guide/[solah_name].tsx
@@ -1,12 +1,13 @@
 import { useLocalSearchParams } from "expo-router/build/hooks";
 
+import { SolahName } from "@/features-solah/types";
 import { SolahGuide } from "@/screens/guide";
 
-function SolahName() {
+function SolahNameScreen() {
   const { solah_name } = useLocalSearchParams();
   const name = Array.isArray(solah_name) ? solah_name[0] : solah_name;
 
-  return <SolahGuide solahName={name} />;
+  return <SolahGuide solahName={name as SolahName} />;
 }
 
-export default SolahName;
+export default SolahNameScreen;

--- a/src/features/solah/components/CurrentSolahIcons.tsx
+++ b/src/features/solah/components/CurrentSolahIcons.tsx
@@ -1,48 +1,18 @@
-import { CloudMoon, CloudSun, MoonStar, Sun, Sunset } from "lucide-react-native";
 import { View, Text } from "react-native";
 
 import { useCurrentSolah } from "@/features-solah/hooks";
+import { SolahName } from "@/features-solah/types";
+import { SolahIcons } from "@/features-solah/utils";
 import { context, fontsize, fontweight } from "@/shared/styles";
 
 const currentIconColor = context.default.inverted;
 const defaultIconColor = context.brand.inverted;
-const iconSize = 18;
-
-const TIMESOFSALAH = [
-  {
-    title: "Subhi",
-    icon: (isCurrent: boolean) => (
-      <CloudMoon color={isCurrent ? currentIconColor : defaultIconColor} size={iconSize} />
-    ),
-  },
-  {
-    title: "Zuhr",
-    icon: (isCurrent: boolean) => (
-      <Sun color={isCurrent ? currentIconColor : defaultIconColor} size={iconSize} />
-    ),
-  },
-  {
-    title: "Asr",
-    icon: (isCurrent: boolean) => (
-      <CloudSun color={isCurrent ? currentIconColor : defaultIconColor} size={iconSize} />
-    ),
-  },
-  {
-    title: "Maghrib",
-    icon: (isCurrent: boolean) => (
-      <Sunset color={isCurrent ? currentIconColor : defaultIconColor} size={iconSize} />
-    ),
-  },
-  {
-    title: "Isha'",
-    icon: (isCurrent: boolean) => (
-      <MoonStar color={isCurrent ? currentIconColor : defaultIconColor} size={iconSize} />
-    ),
-  },
-];
+const iconSize = 16;
 
 export function CurrentSolahIcons() {
   const { currentSolah } = useCurrentSolah();
+  const solahOrder: SolahName[] = ["Subhi", "Dhuhr", "Asr", "Maghrib", "Isha"];
+
   return (
     <View
       style={{
@@ -52,29 +22,35 @@ export function CurrentSolahIcons() {
         gap: 14,
       }}
     >
-      {TIMESOFSALAH.map((time) => (
-        <View
-          key={time.title}
-          style={{
-            flexDirection: "column",
-            alignItems: "center",
-            alignSelf: "flex-start",
-            gap: 2,
-          }}
-        >
-          {time.icon(currentSolah === time.title)}
-          <Text
+      {solahOrder.map((title) => {
+        const Icon = SolahIcons[title];
+        const isCurrent = currentSolah === title;
+        const color = isCurrent ? currentIconColor : defaultIconColor;
+
+        return (
+          <View
+            key={title}
             style={{
-              textAlign: "left",
-              color: currentSolah === time.title ? currentIconColor : defaultIconColor,
-              fontWeight: currentSolah === time.title ? fontweight.extrabold : fontweight.normal,
-              fontSize: fontsize.xs,
+              flexDirection: "column",
+              alignItems: "center",
+              alignSelf: "flex-start",
+              gap: 2,
             }}
           >
-            {time.title}
-          </Text>
-        </View>
-      ))}
+            <Icon color={color} size={iconSize} />
+            <Text
+              style={{
+                textAlign: "left",
+                color,
+                fontWeight: isCurrent ? fontweight.extrabold : fontweight.normal,
+                fontSize: fontsize.xs,
+              }}
+            >
+              {title}
+            </Text>
+          </View>
+        );
+      })}
     </View>
   );
 }

--- a/src/features/solah/components/CurrentSolahTimes.tsx
+++ b/src/features/solah/components/CurrentSolahTimes.tsx
@@ -1,80 +1,51 @@
-import { CloudMoon, CloudSun, MoonStar, Sun, Sunset } from "lucide-react-native";
-import React from "react";
 import { View, Text, StyleSheet } from "react-native";
 
-import { colors, spacing, borderRadius } from "@/shared/styles";
+import { useCurrentLocation, useCurrentSolah, useSolahTimes } from "@/features-solah/hooks";
+import { CalendarFormat } from "@/features-solah/types";
+import { formatDate, SolahIcons } from "@/features-solah/utils";
+import { colors, spacing, borderRadius, font, fontweight } from "@/shared/styles";
 
 interface CurrentSolahTimesProps {
   selectedDate: Date;
 }
 
 export function CurrentSolahTimes({ selectedDate }: CurrentSolahTimesProps) {
-  const solahTimes = [
-    { name: "Subhi", time: "05:45", icon: CloudMoon },
-    { name: "Dhuhr", time: "12:55", icon: Sun },
-    { name: "Asr", time: "17:05", icon: CloudSun },
-    { name: "Maghrib", time: "19:00", icon: Sunset },
-    { name: "Isha'", time: "20:05", icon: MoonStar },
-  ];
+  const { times } = useSolahTimes();
+  const { location } = useCurrentLocation();
+  const { currentSolah } = useCurrentSolah();
 
-  const currentPrayer = "Maghrib";
-
+  const calendarFormat: CalendarFormat = "hijri";
   const dayName = selectedDate.toLocaleDateString("en-US", {
     weekday: "long",
   });
-  const dayNumber = selectedDate.getDate();
-  const year = selectedDate.getFullYear().toString().slice(-2);
+  const locale = "en-US";
 
   return (
     <View style={styles.container}>
       {/* Header section */}
-      <Text style={styles.dateText}>
-        {dayName} • {dayNumber}/{year}
-      </Text>
-      <Text style={styles.locationText}>Ilorin, Kwara State</Text>
+      <View style={styles.dateLocContainer}>
+        <Text style={styles.dateText}>
+          {dayName} • {formatDate(selectedDate, calendarFormat, locale, "collapse")}
+        </Text>
+        <Text style={styles.locationText}>{location}</Text>
+      </View>
 
       {/* Solah Times List */}
-      {solahTimes.map(({ name, time, icon: Icon }) => {
-        const isActive = name === currentPrayer;
+      {times.map(({ title, time }) => {
+        const isActive = title === currentSolah;
+        const Icon = SolahIcons[title];
 
         return (
           <View
-            key={name}
+            key={title}
             style={[styles.row, isActive && { backgroundColor: colors.background.brand.primary }]}
           >
             <View style={styles.left}>
-              <Icon size={20} color="#FDFDFD" style={{ marginRight: 8 }} />
-              <Text
-                style={[
-                  {
-                    color: "#FDFDFD",
-                    marginLeft: spacing.sm,
-                    fontFamily: "Figtree",
-                    fontSize: 14,
-                    fontWeight: "600",
-                    lineHeight: 20,
-                    letterSpacing: 0,
-                  },
-                ]}
-              >
-                {name}
-              </Text>
+              <Icon size={20} color={colors.context.default.inverted} style={{ marginRight: 8 }} />
+              <Text style={styles.rowText}>{title}</Text>
             </View>
 
-            <Text
-              style={[
-                {
-                  color: "#FDFDFD",
-                  fontFamily: "Figtree",
-                  fontSize: 14,
-                  fontWeight: "600",
-                  lineHeight: 20,
-                  letterSpacing: 0,
-                },
-              ]}
-            >
-              {time}
-            </Text>
+            <Text style={styles.rowText}>{time}</Text>
           </View>
         );
       })}
@@ -84,32 +55,25 @@ export function CurrentSolahTimes({ selectedDate }: CurrentSolahTimesProps) {
 
 const styles = StyleSheet.create({
   container: {
-    width: "100%",
-    marginTop: 150, // Added space for SolahCalendar above
     position: "relative",
-    padding: 12,
-    borderRadius: 8,
-    backgroundColor: "#333333",
-    opacity: 1,
-    gap: 16,
-    zIndex: 1, // Ensure proper layering
+    paddingVertical: spacing.s,
+    paddingHorizontal: spacing.xs,
+    borderRadius: borderRadius[4],
+    backgroundColor: colors.background.default.inverted,
+    gap: spacing.m,
+  },
+  dateLocContainer: {
+    gap: spacing["3xs"],
   },
   dateText: {
-    fontFamily: "Figtree",
-    fontSize: 14,
-    fontWeight: "600",
-    lineHeight: 20,
-    letterSpacing: 0,
-    color: "#FDFDFD",
-    opacity: 0.9,
+    ...font.label.small,
+    fontWeight: fontweight.bold,
+    color: colors.context.default.inverted,
   },
   locationText: {
-    fontFamily: "Figtree",
-    fontSize: 14,
+    ...font.body.small,
     fontWeight: "600",
-    lineHeight: 20,
-    letterSpacing: 0,
-    color: "#FDFDFD",
+    color: colors.context.default.tertiary,
     marginBottom: spacing.sm,
   },
   row: {
@@ -124,5 +88,14 @@ const styles = StyleSheet.create({
   left: {
     flexDirection: "row",
     alignItems: "center",
+  },
+  rowText: {
+    color: colors.context.default.inverted,
+    marginLeft: spacing.sm,
+    fontFamily: "Figtree",
+    fontSize: 14,
+    fontWeight: "600",
+    lineHeight: 20,
+    letterSpacing: 0,
   },
 });

--- a/src/features/solah/hooks/useDateAndTime.ts
+++ b/src/features/solah/hooks/useDateAndTime.ts
@@ -1,18 +1,18 @@
 // features/solah/hooks/useDateAndTime.ts
 import { useEffect, useMemo, useState } from "react";
 
+import { CalendarFormat, TimeFormat } from "@/features-solah/types";
+import { formatDate, formatTime } from "@/features-solah/utils";
+
 export interface DateAndTime {
   date: string;
   time: string;
 }
 
-type TimeFormat = "24hr" | "12hr";
-type Calendar = "hijri" | "miladi";
-
 interface UseDateAndTimeOptions {
-  timeFormat?: TimeFormat; // default '24hr'
-  calendar?: Calendar; // default 'hijri'
-  locale?: string; // default 'en-US'
+  timeFormat?: TimeFormat;
+  calendar?: CalendarFormat;
+  locale?: string;
 }
 
 /**
@@ -24,121 +24,12 @@ interface UseDateAndTimeOptions {
  * - Supports Hijri and Miladi (Gregorian) date formatting; Hijri default.
  * - Efficient: updates aligned to the next minute, then every minute.
  */
-export const useDateAndTime = (options: UseDateAndTimeOptions = {}): DateAndTime => {
-  const { timeFormat = "24hr", calendar = "hijri", locale = "en-US" } = options;
-
-  const [current, setCurrent] = useState<Date>(() => new Date());
-
-  // ---- Format Time ----
-  const formatTime = (d: Date): string => {
-    const minutes = d.getMinutes().toString().padStart(2, "0");
-
-    if (timeFormat === "24hr") {
-      const hours = d.getHours().toString().padStart(2, "0");
-      return `${hours}:${minutes}`;
-    }
-
-    const hours24 = d.getHours();
-    const period = hours24 >= 12 ? "PM" : "AM";
-    let hours12 = hours24 % 12;
-    if (hours12 === 0) hours12 = 12;
-    return `${hours12}:${minutes} ${period}`;
-  };
-
-  // ---- Format Date ----
-  const tryIntlDate = (d: Date, useHijri: boolean) => {
-    try {
-      const localeOption = useHijri ? `${locale}-u-ca-islamic` : locale;
-      const formatter = new Intl.DateTimeFormat(localeOption, {
-        day: "numeric",
-        month: "long",
-        year: "numeric",
-      });
-      return formatter.format(d);
-    } catch {
-      return null;
-    }
-  };
-
-  // Approximate arithmetic Hijri fallback (for runtimes without Intl islamic calendar)
-  const hijriFallback = (d: Date): string => {
-    const gY = d.getFullYear();
-    const gM = d.getMonth() + 1;
-    const gD = d.getDate();
-
-    const a = Math.floor((14 - gM) / 12);
-    const y = gY + 4800 - a;
-    const m = gM + 12 * a - 3;
-    const jd =
-      gD +
-      Math.floor((153 * m + 2) / 5) +
-      365 * y +
-      Math.floor(y / 4) -
-      Math.floor(y / 100) +
-      Math.floor(y / 400) -
-      32045;
-
-    const islamicEpoch = 1948439;
-    const days = jd - islamicEpoch;
-    const islamicYear = Math.floor((30 * days + 10646) / 10631);
-
-    const islamicToJd = (iy: number, im: number, id: number) =>
-      id +
-      Math.ceil(29.5 * (im - 1)) +
-      (iy - 1) * 354 +
-      Math.floor((3 + 11 * iy) / 30) +
-      islamicEpoch -
-      1;
-
-    let month = 1;
-    for (let mtest = 1; mtest <= 12; mtest++) {
-      const start = islamicToJd(islamicYear, mtest, 1);
-      const nextStart = islamicToJd(islamicYear, mtest + 1, 1);
-      if (jd >= start && jd < nextStart) {
-        month = mtest;
-        break;
-      }
-    }
-
-    const firstDayOfMonth = islamicToJd(islamicYear, month, 1);
-    const dayOfMonth = jd - firstDayOfMonth + 1;
-
-    const hijriMonths = [
-      "Muharram",
-      "Safar",
-      "Rabi' al-awwal",
-      "Rabi' al-thani",
-      "Jumada al-awwal",
-      "Jumada al-thani",
-      "Rajab",
-      "Sha'ban",
-      "Ramadan",
-      "Shawwal",
-      "Dhu al-Qadah",
-      "Dhu al-Hijjah",
-    ];
-
-    const monthName = hijriMonths[Math.max(0, Math.min(11, month - 1))] ?? `${month}`;
-    return `${dayOfMonth} ${monthName} ${islamicYear}`;
-  };
-
-  const formatDate = (d: Date): string => {
-    const useHijri = calendar === "hijri";
-    const intlResult = tryIntlDate(d, useHijri);
-    if (intlResult) return intlResult;
-    if (useHijri) return hijriFallback(d);
-
-    // Gregorian fallback
-    try {
-      return new Intl.DateTimeFormat(locale, {
-        day: "numeric",
-        month: "long",
-        year: "numeric",
-      }).format(d);
-    } catch {
-      return `${d.getDate()}/${d.getMonth() + 1}/${d.getFullYear()}`;
-    }
-  };
+export const useDateAndTime = ({
+  timeFormat = "24hr",
+  calendar = "hijri",
+  locale = "en-US",
+}: UseDateAndTimeOptions = {}): DateAndTime => {
+  const [current, setCurrent] = useState<Date>(new Date());
 
   // ---- Update aligned to minute boundary ----
   useEffect(() => {
@@ -164,8 +55,8 @@ export const useDateAndTime = (options: UseDateAndTimeOptions = {}): DateAndTime
     };
   }, [timeFormat, calendar, locale]);
 
-  const time = useMemo(() => formatTime(current), [current, timeFormat]);
-  const date = useMemo(() => formatDate(current), [current, calendar, locale]);
+  const time = useMemo(() => formatTime(current), [current]);
+  const date = useMemo(() => formatDate(current), [current]);
 
   return { date, time };
 };

--- a/src/features/solah/hooks/useSolahTimes.ts
+++ b/src/features/solah/hooks/useSolahTimes.ts
@@ -1,57 +1,110 @@
 // useSolah.ts
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
+
+import { SolahName, TimeFormat } from "@/features-solah/types";
 
 export interface SolahTime {
-  title: string;
+  title: SolahName;
   time: string;
 }
 
 const STATIC_SOLAH_TIMES: SolahTime[] = [
   { title: "Subhi", time: "05:12" },
-  { title: "Zuhr", time: "12:33" },
+  { title: "Dhuhr", time: "12:33" },
   { title: "Asr", time: "15:59" },
   { title: "Maghrib", time: "18:01" },
-  { title: "Isha'", time: "19:30" },
+  { title: "Isha", time: "19:30" },
 ];
 
-export function useSolahTimes() {
+// HOOKS
+
+export function useSolahTimes(date: Date = new Date(), timeFormat: TimeFormat = "24hr") {
   const [times, setTimes] = useState<SolahTime[]>(STATIC_SOLAH_TIMES);
 
   // Future reimplementation can fetch or calculate from API
   useEffect(() => {
     // Simulate fetching data
     setTimes(STATIC_SOLAH_TIMES);
-  }, []);
+  }, [date, timeFormat]);
 
   return { times };
 }
 
 export function useCurrentSolah() {
-  // Temporary static current solah
-  const [currentSolah, setCurrentSolah] = useState("Asr");
+  const { times } = useSolahTimes();
+  useMinuteTick();
 
-  useEffect(() => {
-    // Simulate fetching data
-    setCurrentSolah("Asr");
-  }, []);
+  const currentSolah = useMemo(() => getCurrentAndNextSolah(times).current.title, [times]);
 
   return { currentSolah };
 }
 
 export function useNextSolah() {
-  // Temporary static next solah
-  const [nextSolah, setNextSolah] = useState({
-    title: "Maghrib",
-    time: "19:01",
-  });
+  const { times } = useSolahTimes();
+  useMinuteTick();
 
-  useEffect(() => {
-    // Simulate fetching data
-    setNextSolah({
-      title: "Maghrib",
-      time: "19:01",
-    });
-  }, []);
+  const nextSolah = useMemo<SolahTime>(() => getCurrentAndNextSolah(times).next, [times]);
 
   return { nextSolah };
 }
+
+// Helper Hook
+
+const useMinuteTick = () => {
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    const bump = () => setTick((x) => x + 1);
+    const delay = 60000 - (Date.now() % 60000);
+    const t = setTimeout(() => {
+      bump();
+      const i = setInterval(bump, 60000);
+      return () => clearInterval(i);
+    }, delay);
+    return () => clearTimeout(t);
+  }, []);
+};
+
+// Helper Function
+
+const parseTimeToMinutes = (time: string): number => {
+  const t = time.trim().toUpperCase();
+  const match = /^(\d{1,2}):(\d{2})(?:\s*(AM|PM))?$/.exec(t);
+  if (!match) return 0;
+
+  const [, hStr, mStr, period] = match;
+  let h = Number(hStr);
+  const m = Number(mStr);
+
+  if (period) {
+    // 12hr format
+    if (period === "AM" && h === 12) h = 0;
+    if (period === "PM" && h < 12) h += 12;
+  }
+  return h * 60 + m;
+};
+
+const getCurrentMinutes = (): number => {
+  const d = new Date();
+  return d.getHours() * 60 + d.getMinutes();
+};
+
+const getCurrentAndNextSolah = (times: SolahTime[]) => {
+  if (!times.length) {
+    const fallback = { title: "Subhi" as SolahName, time: "00:00" };
+    return { current: fallback, next: fallback };
+  }
+
+  const now = getCurrentMinutes();
+  const mins = times.map((t) => parseTimeToMinutes(t.time));
+  const futureIdx = mins.findIndex((v) => now < v);
+
+  if (futureIdx === -1) {
+    // after last prayer → current = Isha, next = Subhi
+    return { current: times[mins.length - 1], next: times[0] };
+  }
+  if (futureIdx === 0) {
+    // before first prayer → current = Isha (yesterday), next = Subhi
+    return { current: times[mins.length - 1], next: times[0] };
+  }
+  return { current: times[futureIdx - 1], next: times[futureIdx] };
+};

--- a/src/features/solah/types/index.ts
+++ b/src/features/solah/types/index.ts
@@ -1,0 +1,3 @@
+export type SolahName = "Subhi" | "Dhuhr" | "Asr" | "Maghrib" | "Isha";
+export type TimeFormat = "24hr" | "12hr";
+export type CalendarFormat = "hijri" | "miladi";

--- a/src/features/solah/utils/SolahIcons.ts
+++ b/src/features/solah/utils/SolahIcons.ts
@@ -1,0 +1,11 @@
+import { CloudMoon, CloudSun, LucideIcon, MoonStar, Sun, Sunset } from "lucide-react-native";
+
+import { SolahName } from "@/features-solah/types";
+
+export const SolahIcons: Record<SolahName, LucideIcon> = {
+  Subhi: CloudMoon,
+  Dhuhr: Sun,
+  Asr: CloudSun,
+  Maghrib: Sunset,
+  Isha: MoonStar,
+};

--- a/src/features/solah/utils/formatDateAndTime.ts
+++ b/src/features/solah/utils/formatDateAndTime.ts
@@ -1,0 +1,46 @@
+import { CalendarFormat, TimeFormat } from "../types";
+
+// ---- Format Time ----
+export const formatTime = (d: Date, timeFormat: TimeFormat = "24hr"): string => {
+  const minutes = d.getMinutes().toString().padStart(2, "0");
+
+  if (timeFormat === "24hr") {
+    const hours = d.getHours().toString().padStart(2, "0");
+    return `${hours}:${minutes}`;
+  }
+
+  const hours24 = d.getHours();
+  const period = hours24 >= 12 ? "PM" : "AM";
+  let hours12 = hours24 % 12;
+  if (hours12 === 0) hours12 = 12;
+  return `${hours12}:${minutes} ${period}`;
+};
+
+// ---- Format Date ----
+
+export const formatDate = (
+  d: Date,
+  calendar: CalendarFormat = "hijri",
+  locale: string = "en-US",
+  output: "full" | "collapse" = "full"
+): string => {
+  const useHijri = calendar === "hijri";
+
+  const opts: Intl.DateTimeFormatOptions = {
+    day: "numeric",
+    year: "numeric",
+    ...(output === "full" ? { month: "long" } : { month: "numeric", numberingSystem: "latn" }),
+    ...(useHijri ? { calendar: "islamic" } : {}),
+  };
+
+  const fmt = new Intl.DateTimeFormat(locale, opts);
+  const parts = fmt.formatToParts(d);
+
+  const day = parts.find((p) => p.type === "day")?.value ?? "";
+  const month = parts.find((p) => p.type === "month")?.value ?? "";
+  const year = parts.find((p) => p.type === "year")?.value ?? "";
+
+  return output === "full"
+    ? `${day} ${month}, ${year}` // e.g., "4 Rajab, 1447"
+    : `${day}/${month}/${year}`; // e.g., "4/7/1447"
+};

--- a/src/features/solah/utils/index.ts
+++ b/src/features/solah/utils/index.ts
@@ -1,0 +1,2 @@
+export { SolahIcons } from "./SolahIcons";
+export { formatTime, formatDate } from "./formatDateAndTime";

--- a/src/screens/guide/SolahGuide.tsx
+++ b/src/screens/guide/SolahGuide.tsx
@@ -1,9 +1,10 @@
 import { View, Text } from "react-native";
 
+import { SolahName } from "@/features-solah/types";
 import { emptyScreenStyle } from "@/shared/styles";
 
 interface SolahGuideProps {
-  solahName: string;
+  solahName: SolahName;
 }
 
 export function SolahGuide({ solahName }: SolahGuideProps) {


### PR DESCRIPTION
Implemented a twin component of the calendar to display the five daily prayers with icons.
The current prayer is highlighted with distinct styling to improve user experience.